### PR TITLE
Make internal api accessible

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ INSTALL(TARGETS sim headless
 
 INSTALL(FILES kilombo.h DESTINATION include)
 
-INSTALL(FILES kilolib.h message.h message_crc.h params.h
+INSTALL(FILES kilolib.h message.h message_crc.h params.h skilobot.h
 	DESTINATION include/kilombo)
 
 add_subdirectory(tests)

--- a/src/skilobot.h
+++ b/src/skilobot.h
@@ -94,7 +94,11 @@ void separate_clashing_bots(kilobot* bot1, kilobot* bot2);
 void spread_out(int n_bots, double k);
 
 extern kilobot* current_bot;
+
+// we need to supress this declaration in user code
+#ifndef KILOMBO_H
 extern void* mydata;
+#endif
 
 kilobot *Me();
 void prepare_bot(kilobot *bot);


### PR DESCRIPTION
Install skilobot.h together with the other headers. Not usually required
for user code but can be useful sometimes.