### PR TITLE
Straight motion variables values set to the proper values

### DIFF
--- a/src/kbapi.c
+++ b/src/kbapi.c
@@ -32,8 +32,8 @@ uint16_t kilo_uid = 0;
  */
 uint8_t kilo_turn_left  = 75;
 uint8_t kilo_turn_right = 75;
-uint8_t kilo_straight_left = 7;
-uint8_t kilo_straight_right = 7;
+uint8_t kilo_straight_left = 75;
+uint8_t kilo_straight_right = 75;
 
 
 /* Each bot is required to call kilo_init.


### PR DESCRIPTION
Values of kilo_straight_left and kilo_straight_right changed from 7 to
75 as reported by issue #45 (closes #45).